### PR TITLE
Added nCountThreshold to GetBudget

### DIFF
--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -785,7 +785,7 @@ std::vector<CBudgetProposal*> CBudgetManager::GetBudget()
     std::map<uint256, CBudgetProposal>::iterator it1 = mapProposals.begin();
     while (it1 != mapProposals.end()) {
         CBudgetProposal* pBudgetProposal = &((*it1).second);
-        if (pBudgetProposal->mapVotes->size() > nHighestCount &&
+        if (pBudgetProposal->mapVotes.size() > nHighestCount &&
             nBlockHeight >= pBudgetProposal->GetBlockStart() &&
             nBlockHeight <= pBudgetProposal->GetBlockEnd()) {
             nHighestCount = pBudgetProposal->GetVoteCount();

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -794,13 +794,7 @@ std::vector<CBudgetProposal*> CBudgetManager::GetBudget()
         ++it1;
     }
 
-    // ------- Grab The Budgets In Order
-
-    std::vector<CBudgetProposal*> vBudgetProposalsRet;
-
-    CAmount nBudgetAllocated = 0;
-    CBlockIndex* pindexPrev = chainActive.Tip();
-    if (pindexPrev == NULL) return vBudgetProposalsRet;
+    // ------- Grab The Budgets In Order    
 
     int nBlockStart = pindexPrev->nHeight - pindexPrev->nHeight % GetBudgetPaymentCycleBlocks() + GetBudgetPaymentCycleBlocks();
     int nBlockEnd = nBlockStart + GetBudgetPaymentCycleBlocks() - 1;

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -811,7 +811,7 @@ std::vector<CBudgetProposal*> CBudgetManager::GetBudget()
         if (pbudgetProposal->fValid && pbudgetProposal->nBlockStart <= nBlockStart &&
             pbudgetProposal->nBlockEnd >= nBlockEnd &&
             // check the highest budget proposals (+/- 10% to assist in consensus)
-            pbudgetProposal->mapVotes->size() >= nHighestCount - nCountThreshold;
+            pbudgetProposal->mapVotes->size() >= nHighestCount - nCountThreshold &&
             pbudgetProposal->GetYeas() - pbudgetProposal->GetNays() > mnodeman.CountEnabled(ActiveProtocol()) / 10 &&
             pbudgetProposal->IsEstablished()) {
 

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -785,10 +785,10 @@ std::vector<CBudgetProposal*> CBudgetManager::GetBudget()
     std::map<uint256, CBudgetProposal>::iterator it1 = mapProposals.begin();
     while (it1 != mapProposals.end()) {
         CBudgetProposal* pBudgetProposal = &((*it1).second);
-        if (pBudgetProposal->mapVotes.size() > nHighestCount &&
+        if ((int)pBudgetProposal->mapVotes.size() > nHighestCount &&
             nBlockHeight >= pBudgetProposal->GetBlockStart() &&
             nBlockHeight <= pBudgetProposal->GetBlockEnd()) {
-            nHighestCount = pBudgetProposal->mapVotes.size();
+            nHighestCount = (int)pBudgetProposal->mapVotes.size();
         }
 
         ++it1;
@@ -811,7 +811,7 @@ std::vector<CBudgetProposal*> CBudgetManager::GetBudget()
         if (pbudgetProposal->fValid && pbudgetProposal->nBlockStart <= nBlockStart &&
             pbudgetProposal->nBlockEnd >= nBlockEnd &&
             // check the highest budget proposals (+/- 10% to assist in consensus)
-            pbudgetProposal->mapVotes.size() >= nHighestCount - nCountThreshold &&
+            (int)pbudgetProposal->mapVotes.size() >= nHighestCount - nCountThreshold &&
             pbudgetProposal->GetYeas() - pbudgetProposal->GetNays() > mnodeman.CountEnabled(ActiveProtocol()) / 10 &&
             pbudgetProposal->IsEstablished()) {
 

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -785,7 +785,7 @@ std::vector<CBudgetProposal*> CBudgetManager::GetBudget()
     std::map<uint256, CBudgetProposal>::iterator it1 = mapProposals.begin();
     while (it1 != mapProposals.end()) {
         CBudgetProposal* pBudgetProposal = &((*it1).second);
-        if (pBudgetProposal->GetVoteCount() > nHighestCount &&
+        if (pBudgetProposal->mapVotes->size() > nHighestCount &&
             nBlockHeight >= pBudgetProposal->GetBlockStart() &&
             nBlockHeight <= pBudgetProposal->GetBlockEnd()) {
             nHighestCount = pBudgetProposal->GetVoteCount();

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -788,7 +788,7 @@ std::vector<CBudgetProposal*> CBudgetManager::GetBudget()
         if (pBudgetProposal->mapVotes.size() > nHighestCount &&
             nBlockHeight >= pBudgetProposal->GetBlockStart() &&
             nBlockHeight <= pBudgetProposal->GetBlockEnd()) {
-            nHighestCount = pBudgetProposal->GetVoteCount();
+            nHighestCount = pBudgetProposal->mapVotes.size();
         }
 
         ++it1;
@@ -811,7 +811,7 @@ std::vector<CBudgetProposal*> CBudgetManager::GetBudget()
         if (pbudgetProposal->fValid && pbudgetProposal->nBlockStart <= nBlockStart &&
             pbudgetProposal->nBlockEnd >= nBlockEnd &&
             // check the highest budget proposals (+/- 10% to assist in consensus)
-            pbudgetProposal->mapVotes->size() >= nHighestCount - nCountThreshold &&
+            pbudgetProposal->mapVotes.size() >= nHighestCount - nCountThreshold &&
             pbudgetProposal->GetYeas() - pbudgetProposal->GetNays() > mnodeman.CountEnabled(ActiveProtocol()) / 10 &&
             pbudgetProposal->IsEstablished()) {
 


### PR DESCRIPTION
This change should be done to avoid finalizing budgets that don't pass the nCountThreshold threshold. Changing the > to >= will also eliminate the minimum requirement of 10 masternodes which is most likely an unintentional check. If there should be a minimum requirements of masternodes, I think it should be clarified and implemented through another parameter.
